### PR TITLE
ACLX-72 AccessLex | Store Custom Data Points of Learner

### DIFF
--- a/lib/bigcommerce/resources/customers/customer.rb
+++ b/lib/bigcommerce/resources/customers/customer.rb
@@ -26,6 +26,7 @@ module Bigcommerce
     property :addresses
     property :tax_exempt_category
     property :accepts_marketing
+    property :form_fields
 
     def self.count(params = {})
       get 'customers/count', params


### PR DESCRIPTION
Form fields exist on Customer but are missing from the customer resource object.

Schema definition:

  $ curl https://developer.bigcommerce.com/api-reference/store-management/customers-v2/BigCommerce_Customers_API.oas2.json | jq '.definitions.Customer.properties.form_fields'

  {
    "description": "Array of custom fields. This is a READ-ONLY field; do not set or modify its value in a POST or PUT request.",
    "type": "array",
    "items": {
      "title": "Form Fields",
      "type": "object",
      "properties": {
        "name": {
          "description": "Name of the form field",
          "type": "string",
          "example": "License Id"
        },
        "value": {
          "description": "Value of the form field",
          "type": "string",
          "example": "123BAF"
        }
      }
    }
  }

#### What?

A description about what this pull request implements and its purpose. Try to be detailed and describe any technical details to simplify the job of the reviewer and the individual on production support.

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Link 1](http://example.com)
- ...

#### Screenshots (if appropriate)

Attach images or add image links here.

![Example Image](http://placehold.it/300x200)
